### PR TITLE
Upgrade to Keycloak 22.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ To safeguard registration against bots, Keycloak has integration with Google reC
 
 ## Installation
 
-Download the newest release JAR (or comile it yourself) and drop it into `your_keycloak_installation/providers`
+Download the newest release JAR (or compile it yourself - see below) and drop it into `your_keycloak_installation/providers`
 
 There are a few steps you need to perform in the Keycloak Admin Console. Click the Authentication left menu item and go to the Flows tab. Select the Registration flow from the drop down list on this page.
 
@@ -28,7 +28,7 @@ Authorizing Iframes
 
 To show the hCaptcha you need to modify the registration template. You can find the files in your Keycloak installation under `themes/base/login/`. If you use the user profile preview (you start your Keycloak with the `-Dkeycloak.profile=preview` flag), you need to edit the `register-user-profile.ftl`, else the `register.ftl`. Add the following code beneith the reCaptcha code:
 
-```
+```html
 <#if hcaptchaRequired??>
     <div class="form-group">
         <div class="${properties.kcInputWrapperClass!}">
@@ -45,6 +45,26 @@ In the last step you have to change the registration flow to the newly created o
 
 Authentication Bindings
 ![Step 6](img/step-06.png)
+
+## Compiling it yourself
+
+Clone the repository:
+
+```bash
+git clone https://github.com/p08dev/keycloak-hcaptcha.git
+```
+
+Inside the repository, compile it using Maven with Java 17:
+
+```bash
+mvn clean compile package
+```
+
+You can instruct Maven to use a specific Java version by prepending the JAVA_HOME environment variable:
+
+```bash
+JAVA_HOME=/usr/lib/jvm/java-17-oracle/ mvn clean compile package
+```
 
 ## © License
 [MIT](LICENSE)

--- a/pom.xml
+++ b/pom.xml
@@ -2,15 +2,15 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>de.itrupp.p8</groupId>
   <artifactId>keycloak-hcaptcha</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <name>Registration Authenitcation Execution Provider for hCaptcha</name>
   <description>hCaptcha protects your users' privacy, rewards websites and helps businesses annotate their data. It's a 'drop in' replacement for reCAPTCHA that you set up in minutes.</description>
   <packaging>jar</packaging>
 
   <properties>
-    <version.keycloak>21.0.1</version.keycloak>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <version.keycloak>22.0.5</version.keycloak>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/src/main/java/de/itrupp/p8/keycloak/authenticator/RegistrationhCaptcha.java
+++ b/src/main/java/de/itrupp/p8/keycloak/authenticator/RegistrationhCaptcha.java
@@ -25,7 +25,7 @@ import org.keycloak.services.messages.Messages;
 import org.keycloak.services.validation.Validation;
 import org.keycloak.util.JsonSerialization;
 
-import javax.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 
 import java.io.InputStream;
 import java.util.ArrayList;


### PR DESCRIPTION
Keycloak 22 migrated from Java EE to Jakarta EE which results in a namespace change from `javax.*` to `jakarata.*`.
This pull requests addresses this change and also sets the compile and target version to `17`.

Also, I've added compiling instructions to the README and bumped the version to **1.0.1**.